### PR TITLE
Add filter-callrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test/data/sample_maps/
 libs/
 
 .env
+libs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,8 @@ repos:
     entry: pylint
     language: system
     types: [python]
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.812
+  hooks:
+  - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     language: system
     types: [python]
 
+# Static type analysis (as much as it's possible in python using type hints)
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.812
   hooks:

--- a/joint_calling/pop_strat_qc.py
+++ b/joint_calling/pop_strat_qc.py
@@ -389,7 +389,7 @@ def _compute_sample_rankings(
             hl.len(hard_filtered_samples_ht[ht.key].hard_filters) > 0, False
         ),
     )
-    if use_qc_metrics_filters:
+    if use_qc_metrics_filters and regressed_metrics_ht is not None:
         ht = ht.annotate(
             filtered=hl.cond(
                 ht.filtered,

--- a/joint_calling/utils.py
+++ b/joint_calling/utils.py
@@ -94,7 +94,7 @@ def file_exists(path: str) -> bool:
     return os.path.exists(path)
 
 
-def gs_cache_file(fpath: str, local_tmp_dir: str = None) -> str:
+def gs_cache_file(fpath: str, local_tmp_dir: str) -> str:
     """
     :param fpath: local or a `gs://` path. If the latter, the file
         will be downloaded and cached if local_tmp_dir is provided,

--- a/scripts/sample_qc.py
+++ b/scripts/sample_qc.py
@@ -236,7 +236,7 @@ def _filter_callrate(
     mt: hl.MatrixTable,
     work_bucket: str,
     overwrite: bool = False,
-) -> hl.Table:
+) -> hl.MatrixTable:
     """
     Filter non-common variants, and annotate the sample callrate
     :param mt: input matrix table


### PR DESCRIPTION
Filter input samples by the call rate threshold.

Borrowed from the gnomAD QC pipeline: https://github.com/broadinstitute/gnomad_qc/blob/d63c00f9fd3e38b9c2606c61ac868713faee5d34/gnomad_qc/v2/sample_qc/apply_hard_filters.py#L100-L103 (with more details in the [gnomAD paper](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-020-2308-7/MediaObjects/41586_2020_2308_MOESM1_ESM.pdf), page 7).