### PR TITLE
Add comment about spanning del, fix `AS_SB_TABLE` parsing, fix overwriting

### DIFF
--- a/scripts/load_vqsr.py
+++ b/scripts/load_vqsr.py
@@ -92,9 +92,11 @@ def main(  # pylint: disable=missing-function-docstring
             AS_VQSLOD=ht.info.AS_VQSLOD.map(hl.float),
             AS_QUALapprox=ht.info.AS_QUALapprox.split(r'\|')[1:].map(hl.int),
             AS_VarDP=ht.info.AS_VarDP.split(r'\|')[1:].map(hl.int),
-            AS_SB_TABLE=ht.info.AS_SB_TABLE.split(r'\|')
-            .filter(lambda v: v != '')
-            .map(lambda x: x.split(',').map(hl.int)),
+            AS_SB_TABLE=ht.info.AS_SB_TABLE.split(r'\|').map(
+                lambda x: hl.if_else(
+                    x == '', hl.missing(hl.tarray(hl.tint32)), x.split(',').map(hl.int)
+                )
+            ),
         )
     )
 

--- a/scripts/make_finalised_mt.py
+++ b/scripts/make_finalised_mt.py
@@ -8,7 +8,7 @@ import logging
 import click
 import hail as hl
 
-from joint_calling.utils import get_validation_callback, get_mt
+from joint_calling.utils import get_validation_callback, get_mt, file_exists
 from joint_calling import utils, _version
 
 logger = logging.getLogger('joint-calling')
@@ -74,6 +74,15 @@ def main(
     """
     utils.init_hail('make_finalised_mt', local_tmp_dir)
 
+    if file_exists(out_mt_path):
+        if overwrite:
+            logger.info(f'Output {out_mt_path} exists and will be overwritten')
+        else:
+            logger.info(
+                f'Output file {out_mt_path} exists, use --overwrite to overwrite'
+            )
+            return
+
     mt = get_mt(
         mt_path,
         split=True,
@@ -84,7 +93,7 @@ def main(
     var_qc_ht = hl.read_table(var_qc_final_filter_ht_path)
     mt = mt.annotate_rows(**var_qc_ht[mt.row_key])
     mt = mt.annotate_globals(**var_qc_ht.index_globals())
-    mt.write(out_mt_path)
+    mt.write(out_mt_path, overwrite=True)
 
 
 if __name__ == '__main__':

--- a/scripts/mt_to_vcf.py
+++ b/scripts/mt_to_vcf.py
@@ -140,9 +140,16 @@ def mt_to_sites_only_ht(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
 
 
 def _filter_rows_and_add_tags(mt: hl.MatrixTable) -> hl.MatrixTable:
-    """Filter rows and add tags"""
     mt = hl.experimental.densify(mt)
-    # Filter to only non-reference sites
+
+    # Filter to only non-reference sites.
+    # An examle of a variant with hl.len(mt.alleles) > 1 BUT NOT
+    # hl.agg.any(mt.LGT.is_non_ref()) is a variant that spans a deletion,
+    # which was however filtered out, so the LGT was set to NA, however the site
+    # was preserved to account for the presence of that spanning deletion.
+    # locus   alleles    LGT
+    # chr1:1 ["GCT","G"] 0/1
+    # chr1:3 ["T","*"]   NA
     mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.LGT.is_non_ref())))
 
     # annotate site level DP as site_dp onto the mt rows to avoid name collision


### PR DESCRIPTION
3 minor updates:

1. Add a comment into `mt_to_vcf.py` about filtering to non-ref alleles (`*` allele and spanning deletions).
2. In `AS_SB_TABLE` parsing, keep empty fields as `NA` to allow further indexing the array with an `a_index` after splitting multiallelics
3. Fix overwriting existing matrix table in `make_finalised_mt.py`