### PR TITLE
Validate MD5 

### DIFF
--- a/joint_calling/upload_processor.py
+++ b/joint_calling/upload_processor.py
@@ -13,13 +13,21 @@
     - User must be authenticated with appropriate permissions """
 
 import os
-from typing import List, Optional
+from typing import List, Optional, NamedTuple
 import hailtop.batch as hb
+
+
+class SampleGroup(NamedTuple):
+    """ Defines a group of files associated with each sample"""
+
+    data_file: str
+    tbi: str
+    md5: str
 
 
 def batch_move_files(
     batch: hb.batch,
-    files: List[str],
+    files: SampleGroup,
     source_prefix: str,
     destination_prefix: str,
     docker_image: Optional[str] = None,
@@ -32,9 +40,9 @@ def batch_move_files(
     ==========
     batch: hb.Batch
         An object representing the DAG of jobs to run.
-    files: List[str]
-        A list of the file names to be moved.
-        For example ["TOB1543.g.vcf.gz","TOB2314.g.vcf.gz","TOB3423.g.vcf.gz"]
+    files: SampleGroup
+        A NamedTuple containing 3 files to be moved.
+        For example ["TOB1543.g.vcf.gz","TOB1543.g.vcf.tbi","TOB1543.g.vcf.md5"]
     source_prefix: str
         The path to the sub-directory where the files are initially located.
         For example "cpg-tob-wgs-upload" or "cpg-tob-wgs-upload/v1"

--- a/joint_calling/upload_processor.py
+++ b/joint_calling/upload_processor.py
@@ -21,7 +21,7 @@ class SampleGroup(NamedTuple):
     """ Defines a group of files associated with each sample"""
 
     data_file: str
-    index: str
+    test_index: str
     md5: str
 
 

--- a/joint_calling/upload_processor.py
+++ b/joint_calling/upload_processor.py
@@ -21,7 +21,7 @@ class SampleGroup(NamedTuple):
     """ Defines a group of files associated with each sample"""
 
     data_file: str
-    tbi: str
+    index: str
     md5: str
 
 

--- a/joint_calling/upload_processor.py
+++ b/joint_calling/upload_processor.py
@@ -21,7 +21,7 @@ class SampleGroup(NamedTuple):
     """ Defines a group of files associated with each sample"""
 
     data_file: str
-    test_index: str
+    index_file: str
     md5: str
 
 

--- a/scripts/process_uploads.py
+++ b/scripts/process_uploads.py
@@ -80,7 +80,8 @@ def setup_job(batch: hb.batch, name: str, docker_image: Optional[str]):
     """ Define a new hail batch job """
 
     new_j = batch.new_job(name=name)
-    new_j.image(docker_image)
+    if docker_image is not None:
+        new_j.image(docker_image)
     # Uncomment for local testing.
     # key = os.environ.get('GSA_KEY')
     # new_j.command(f"echo '{key}' > /tmp/key.json")

--- a/scripts/process_uploads.py
+++ b/scripts/process_uploads.py
@@ -82,10 +82,7 @@ def setup_job(batch: hb.batch, name: str, docker_image: Optional[str]):
     new_j = batch.new_job(name=name)
     if docker_image is not None:
         new_j.image(docker_image)
-    # Uncomment for local testing.
-    # key = os.environ.get('GSA_KEY')
-    # new_j.command(f"echo '{key}' > /tmp/key.json")
-    # new_j.command(f'gcloud -q auth activate-service-account --key-file=/tmp/key.json')
+
     new_j.command(
         'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
     )

--- a/scripts/process_uploads.py
+++ b/scripts/process_uploads.py
@@ -96,14 +96,14 @@ def validate_md5(job: hb.batch.job, sample_group: List[str], upload_path: str):
     and comparing this with the uploaded .md5."""
 
     # Generate paths to files that are being validated
-    sample_gvcf = sample_group[0]
+    sample_data = sample_group[0]
     md5_file = sample_group[2]
-    path_to_gvcf = join('gs://', upload_path, sample_gvcf)
+    path_to_data = join('gs://', upload_path, sample_data)
     path_to_md5 = join('gs://', upload_path, md5_file)
 
     # Calculate md5 checksum.
     job.command(
-        f'gsutil cat {path_to_gvcf} | md5sum | sed "s/-/{sample_gvcf}/" > {job.ofile}'
+        f'gsutil cat {path_to_data} | md5sum | sed "s/-/{sample_data}/" > {job.ofile}'
     )
     job.command(f'diff <( cat {job.ofile} ) <(gsutil cat {path_to_md5})')
 


### PR DESCRIPTION
Validates that the md5 file matches the corresponding gvcf or cram file that it was generated from. 
Restructured process_uploads to process files associated with each sample as a series of dependent jobs to facilitate the md5 validation. 