### PR TITLE
Matrix table output updates

### DIFF
--- a/joint_calling/utils.py
+++ b/joint_calling/utils.py
@@ -342,17 +342,6 @@ def get_mt(
     """
     mt = hl.read_matrix_table(mt_path)
 
-    # keying by locus and allele
-    mt = hl.MatrixTable(
-        hl.ir.MatrixKeyRowsBy(
-            mt._mir,  # pylint: disable=protected-access
-            ['locus', 'alleles'],
-            # Prevent hail from running sort on genotype MT which is already sorted
-            # by a unique locus
-            is_sorted=True,
-        )
-    )
-
     if hard_filtered_samples_to_remove_ht is not None:
         mt = mt.filter_cols(
             hl.is_missing(hard_filtered_samples_to_remove_ht[mt.col_key])

--- a/scripts/make_finalised_mt.py
+++ b/scripts/make_finalised_mt.py
@@ -8,7 +8,7 @@ import logging
 import click
 import hail as hl
 
-from joint_calling.utils import get_validation_callback, get_mt, file_exists
+from joint_calling.utils import get_validation_callback, file_exists
 from joint_calling import utils, _version
 
 logger = logging.getLogger('joint-calling')
@@ -30,6 +30,13 @@ logger.setLevel('INFO')
     required=True,
     callback=get_validation_callback(ext='mt', must_exist=False),
     help='path to write the final annotated soft-filtered Matrix Table',
+)
+@click.option(
+    '--out-nonref-mt',
+    'out_nonref_mt_path',
+    required=True,
+    callback=get_validation_callback(ext='mt', must_exist=False),
+    help='write a version of output Matrix Table without reference blocks',
 )
 @click.option(
     '--meta-ht',
@@ -63,6 +70,7 @@ logger.setLevel('INFO')
 def main(
     mt_path: str,
     out_mt_path: str,
+    out_nonref_mt_path: str,
     meta_ht_path: str,
     var_qc_final_filter_ht_path: str,
     local_tmp_dir: str,
@@ -80,17 +88,18 @@ def main(
             )
             return
 
-    mt = get_mt(
-        mt_path,
-        split=True,
-        meta_ht=hl.read_table(meta_ht_path),
-        add_meta=True,
-    )
+    mt = hl.read_matrix_table(mt_path)
+
+    meta_ht = hl.read_table(meta_ht_path)
+    mt = mt.annotate_cols(meta=meta_ht[mt.col_key])
 
     var_qc_ht = hl.read_table(var_qc_final_filter_ht_path)
     mt = mt.annotate_rows(**var_qc_ht[mt.row_key])
     mt = mt.annotate_globals(**var_qc_ht.index_globals())
     mt.write(out_mt_path, overwrite=True)
+
+    mt = mt.filter_rows(hl.agg.any(mt.LGT.is_non_ref()))
+    mt.write(out_nonref_mt_path, overwrite=True)
 
 
 if __name__ == '__main__':

--- a/workflows/batch_workflow.py
+++ b/workflows/batch_workflow.py
@@ -174,10 +174,12 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stateme
     filtered_combined_nonref_mt_path = f'{mt_output_bucket}/{callset_version}-nonref.mt'
     readme_fpath = f'{mt_output_bucket}/README.txt'
     with hadoop_open(readme_fpath, 'w') as f:
-        f.write(f'Unfiltered: {basename(raw_combined_mt_path)}')
-        f.write(f'AS-VQSR soft-filtered: {basename(filtered_combined_mt_path)}')
+        f.write(f'Unfiltered:\n{basename(raw_combined_mt_path)}')
         f.write(
-            f'AS-VQSR soft-filtered, without reference blocks: {basename(filtered_combined_nonref_mt_path)}'
+            f'AS-VQSR soft-filtered\n(use `mt.filter_rows(hl.is_missing(mt.filters)` to hard-filter):\n {basename(filtered_combined_mt_path)}'
+        )
+        f.write(
+            f'AS-VQSR soft-filtered, without reference blocks:\n{basename(filtered_combined_nonref_mt_path)}'
         )
 
     combiner_bucket = f'{work_bucket}/combiner'

--- a/workflows/batch_workflow.py
+++ b/workflows/batch_workflow.py
@@ -310,7 +310,7 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stateme
                 max_age='8h',
                 packages=utils.DATAPROC_PACKAGES,
                 num_secondary_workers=scatter_count,
-                depends_on=[var_qc_job],
+                depends_on=[var_qc_job, combiner_job],
                 job_name='Making final MT',
             )
         else:


### PR DESCRIPTION
* Make sure the final soft-filtered matrix table is annotated with `LGT` (see https://github.com/populationgenomics/ancestry/pull/82), cc @KatalinaBobowik 
* Save the raw matrix table (that comes from the combiner and doesn't have soft-filters) to a temporary bucket.
* Add a version of the matrix table without the reference blocks (`-nonref.mt`), cc @tiboloic.

Sucessful run in `test`: https://batch.hail.populationgenomics.org.au/batches/3353, output matrix table without reference blocks, annotated with LGT: `gs://cpg-tob-wgs-test/mt/v3.2-nonref.mt/`
